### PR TITLE
Bug fix: change type notation in qaekwy/response.py

### DIFF
--- a/qaekwy/response.py
+++ b/qaekwy/response.py
@@ -40,7 +40,7 @@ Note:
 
 """
 from abc import ABC
-
+from typing import List
 import json
 from qaekwy.explanation import Explanation
 
@@ -278,7 +278,7 @@ class SolutionResponse(AbstractResponse):
 
     """
 
-    def get_solutions(self) -> list[Solution]:
+    def get_solutions(self) -> List[Solution]:
         """
         Retrieve a list of solutions provided by the engine.
 


### PR DESCRIPTION
Change type notation in qaekwy/response.py SolutionResponse.get_solutions. the code list[Solution] causes TypeError: 'type' object is not subscriptable.